### PR TITLE
EIP1-8404: Return bad request for historic search earliest date before 1970

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/exception/Pre1970EarliestSearchException.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/exception/Pre1970EarliestSearchException.kt
@@ -1,0 +1,10 @@
+package uk.gov.dluhc.registercheckerapi.exception
+
+import java.time.Instant
+import java.util.UUID
+
+/**
+ * Thrown when the historic search earliest date is before 1970 UTC, as this cannot be saved to the DB as a timestamp
+ */
+class Pre1970EarliestSearchException(requestId: UUID, earliestSearchDateTime: Instant?) :
+    RuntimeException("Request requestId:[$requestId] cannot have historicalSearchEarliestDate:[$earliestSearchDateTime] as dates before 1970 UTC are not valid")

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/mapper/RegisterCheckResultMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/mapper/RegisterCheckResultMapper.kt
@@ -4,7 +4,6 @@ import org.apache.commons.lang3.StringUtils
 import org.mapstruct.Mapper
 import org.mapstruct.Mapping
 import org.mapstruct.Named
-import org.springframework.beans.factory.annotation.Autowired
 import uk.gov.dluhc.registercheckerapi.dto.AddressDto
 import uk.gov.dluhc.registercheckerapi.dto.PersonalDetailDto
 import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckMatchDto
@@ -24,9 +23,6 @@ import uk.gov.dluhc.registercheckerapi.database.entity.RegisterCheckMatch as Reg
     ]
 )
 abstract class RegisterCheckResultMapper {
-    @Autowired
-    protected lateinit var instantMapper: InstantMapper
-
     @Mapping(target = "requestId", source = "queryParamRequestId")
     @Mapping(target = "correlationId", source = "apiRequest.requestid")
     @Mapping(target = "matchResultSentAt", source = "apiRequest.createdAt")

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/rest/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/rest/GlobalExceptionHandler.kt
@@ -18,6 +18,7 @@ import uk.gov.dluhc.registercheckerapi.client.IerEroNotFoundException
 import uk.gov.dluhc.registercheckerapi.config.ApiRequestErrorAttributes
 import uk.gov.dluhc.registercheckerapi.exception.GssCodeMismatchException
 import uk.gov.dluhc.registercheckerapi.exception.PendingRegisterCheckNotFoundException
+import uk.gov.dluhc.registercheckerapi.exception.Pre1970EarliestSearchException
 import uk.gov.dluhc.registercheckerapi.exception.RegisterCheckMatchCountMismatchException
 import uk.gov.dluhc.registercheckerapi.exception.RegisterCheckUnexpectedStatusException
 import uk.gov.dluhc.registercheckerapi.exception.RequestIdMismatchException
@@ -63,7 +64,8 @@ class GlobalExceptionHandler(
     @ExceptionHandler(
         value = [
             RequestIdMismatchException::class,
-            RegisterCheckMatchCountMismatchException::class
+            RegisterCheckMatchCountMismatchException::class,
+            Pre1970EarliestSearchException::class,
         ]
     )
     protected fun handleBadRequestBusinessException(


### PR DESCRIPTION
https://dluhcdigital.atlassian.net/browse/EIP1-8404

TIMESTAMP type for this field in the DB cannot store any date below 1970, so we should return a bad request when we receive a pre-1970 date