### PR TITLE
EROPSPT-257: Add an ARCHIVED status for register checks

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/entity/RegisterCheck.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/entity/RegisterCheck.kt
@@ -166,6 +166,7 @@ enum class SourceType {
 
 enum class CheckStatus {
     PENDING,
+    ARCHIVED, // A check can be manually archived if it is no longer needed and unable to be processed by a particular EMS
     NO_MATCH,
     EXACT_MATCH,
     PARTIAL_MATCH, // A single result from the EMS that differs slightly from our elector's details (e.g. different first name)

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/mapper/CheckStatusMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/mapper/CheckStatusMapper.kt
@@ -21,5 +21,6 @@ interface CheckStatusMapper {
     @ValueMapping(target = "EXPIRED", source = "EXPIRED")
     @ValueMapping(target = "NOT_MINUS_STARTED", source = "NOT_STARTED")
     @ValueMapping(target = MappingConstants.THROW_EXCEPTION, source = "PENDING")
+    @ValueMapping(target = MappingConstants.THROW_EXCEPTION, source = "ARCHIVED")
     fun toRegisterCheckResultEnum(checkStatus: CheckStatus): RegisterCheckResult
 }

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/RegisterCheckServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/RegisterCheckServiceTest.kt
@@ -284,7 +284,7 @@ internal class RegisterCheckServiceTest {
         @ParameterizedTest
         @EnumSource(
             value = CheckStatus::class,
-            names = ["NO_MATCH", "EXACT_MATCH", "MULTIPLE_MATCH", "TOO_MANY_MATCHES"]
+            names = ["NO_MATCH", "EXACT_MATCH", "MULTIPLE_MATCH", "TOO_MANY_MATCHES", "ARCHIVED"]
         )
         fun `should throw RegisterCheckUnexpectedStatusException when existing register check status is not PENDING`(
             existingCheckStatusInDb: CheckStatus,


### PR DESCRIPTION
This would allow us to remove register checks that are no longer needed, for example because the application has already been fully processed or because a new register check with updated details has been submitted, in cases where the EMS is not able to respond to the register check for some reason.

Once this is deployed, I'd like to do a one-off query to find all register checks for applications that have been determined, and remove them, to make it easier to see which register checks are remaining and reach out to EROs with stuck register checks.