### PR TITLE
EIP1-8990: Historic register checks should not return the EXPIRED status

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/service/MatchStatusResolver.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/service/MatchStatusResolver.kt
@@ -38,7 +38,7 @@ class MatchStatusResolver {
     private fun evaluateRegisterCheckStatusWithOneMatch(
         registerCheckMatchDto: RegisterCheckMatchDto,
         personalDetailEntity: PersonalDetail,
-        isHistoricCheck: Boolean = false,
+        isHistoricalSearch: Boolean = false,
     ): RegisterCheckStatus =
         with(registerCheckMatchDto) {
             return if (equalsIgnoreCase(franchiseCode.trim(), "PENDING")) {
@@ -47,7 +47,7 @@ class MatchStatusResolver {
                 val now = LocalDate.now()
                 if (registeredStartDate?.isAfter(now) == true) {
                     RegisterCheckStatus.NOT_STARTED
-                } else if (!isHistoricCheck && registeredEndDate?.isBefore(now) == true) {
+                } else if (!isHistoricalSearch && registeredEndDate?.isBefore(now) == true) {
                     RegisterCheckStatus.EXPIRED
                 } else if (isPartialMatch(registerCheckMatchDto.personalDetail, personalDetailEntity)) {
                     RegisterCheckStatus.PARTIAL_MATCH

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/service/MatchStatusResolver.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/service/MatchStatusResolver.kt
@@ -26,7 +26,8 @@ class MatchStatusResolver {
             0 -> RegisterCheckStatus.NO_MATCH
             1 -> evaluateRegisterCheckStatusWithOneMatch(
                 registerCheckResultDto.registerCheckMatches!!.first(),
-                registerCheckEntity.personalDetail
+                registerCheckEntity.personalDetail,
+                registerCheckEntity.historicalSearch == true,
             )
 
             in 2..10 -> RegisterCheckStatus.MULTIPLE_MATCH
@@ -36,7 +37,8 @@ class MatchStatusResolver {
 
     private fun evaluateRegisterCheckStatusWithOneMatch(
         registerCheckMatchDto: RegisterCheckMatchDto,
-        personalDetailEntity: PersonalDetail
+        personalDetailEntity: PersonalDetail,
+        isHistoricCheck: Boolean = false,
     ): RegisterCheckStatus =
         with(registerCheckMatchDto) {
             return if (equalsIgnoreCase(franchiseCode.trim(), "PENDING")) {
@@ -45,7 +47,7 @@ class MatchStatusResolver {
                 val now = LocalDate.now()
                 if (registeredStartDate?.isAfter(now) == true) {
                     RegisterCheckStatus.NOT_STARTED
-                } else if (registeredEndDate?.isBefore(now) == true) {
+                } else if (!isHistoricCheck && registeredEndDate?.isBefore(now) == true) {
                     RegisterCheckStatus.EXPIRED
                 } else if (isPartialMatch(registerCheckMatchDto.personalDetail, personalDetailEntity)) {
                     RegisterCheckStatus.PARTIAL_MATCH

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/MatchStatusResolverTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/MatchStatusResolverTest.kt
@@ -8,9 +8,9 @@ import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus
 import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.EXACT_MATCH
 import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.EXPIRED
+import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.NOT_STARTED
 import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.PARTIAL_MATCH
 import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.PENDING_DETERMINATION
-import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.NOT_STARTED
 import uk.gov.dluhc.registercheckerapi.testsupport.testdata.dto.buildAddressDto
 import uk.gov.dluhc.registercheckerapi.testsupport.testdata.dto.buildPersonalDetailDto
 import uk.gov.dluhc.registercheckerapi.testsupport.testdata.dto.buildRegisterCheckMatchDto

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/MatchStatusResolverTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/MatchStatusResolverTest.kt
@@ -56,7 +56,7 @@ internal class MatchStatusResolverTest {
         franchiseCode: String,
         relativeRegisteredStartDate: Long?,
         relativeRegisteredEndDate: Long?,
-        isHistoricCheck: Boolean?,
+        isHistoricalSearch: Boolean?,
         expectedStatus: RegisterCheckStatus
     ) {
         // Given
@@ -85,7 +85,7 @@ internal class MatchStatusResolverTest {
                     postcode = personalDetailDto.address.postcode,
                 )
             ),
-            historicalSearch = isHistoricCheck == true,
+            historicalSearch = isHistoricalSearch == true,
         )
 
         // When
@@ -245,7 +245,7 @@ internal class MatchStatusResolverTest {
             val twoDaysFromNow = 2L
             val emptyFranchiseCode = ""
             val pendingFranchiseCode = "PENDING"
-            val isHistoricCheck = true
+            val isHistoricalSearch = true
             return Stream.of(
                 Arguments.of(emptyFranchiseCode, null, null, null, EXACT_MATCH),
                 Arguments.of(emptyFranchiseCode, null, twoDaysFromNow, null, EXACT_MATCH),
@@ -256,7 +256,7 @@ internal class MatchStatusResolverTest {
                 Arguments.of(pendingFranchiseCode, null, null, null, PENDING_DETERMINATION),
                 Arguments.of(emptyFranchiseCode, twoDaysFromNow, twoDaysFromNow, null, NOT_STARTED),
                 Arguments.of(emptyFranchiseCode, twoDaysAgo, twoDaysAgo, null, EXPIRED),
-                Arguments.of(emptyFranchiseCode, twoDaysAgo, twoDaysAgo, isHistoricCheck, EXACT_MATCH),
+                Arguments.of(emptyFranchiseCode, twoDaysAgo, twoDaysAgo, isHistoricalSearch, EXACT_MATCH),
                 Arguments.of(emptyFranchiseCode, twoDaysFromNow, twoDaysFromNow, null, NOT_STARTED),
             )
         }

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/MatchStatusResolverTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/MatchStatusResolverTest.kt
@@ -6,7 +6,11 @@ import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus
-import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.*
+import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.EXACT_MATCH
+import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.EXPIRED
+import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.PARTIAL_MATCH
+import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.PENDING_DETERMINATION
+import uk.gov.dluhc.registercheckerapi.dto.RegisterCheckStatus.NOT_STARTED
 import uk.gov.dluhc.registercheckerapi.testsupport.testdata.dto.buildAddressDto
 import uk.gov.dluhc.registercheckerapi.testsupport.testdata.dto.buildPersonalDetailDto
 import uk.gov.dluhc.registercheckerapi.testsupport.testdata.dto.buildRegisterCheckMatchDto


### PR DESCRIPTION
The register check API should not return the EXPIRED status if the register check request is made with the historicalSearch field is set to true.