### PR TITLE
EROPSPT-289: Add index on correlation id to register check result data

### DIFF
--- a/src/main/resources/db/changelog/db.changelog-master.xml
+++ b/src/main/resources/db/changelog/db.changelog-master.xml
@@ -18,5 +18,6 @@
     <include relativeToChangelogFile="true" file="ddl/0010_add_ems_elector_id_and_historical_search_columns.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0011_add_historical_search_earliest_date_column.xml"/>
     <include relativeToChangelogFile="true" file="ddl/0012_voting_arrangement.xml"/>
+    <include relativeToChangelogFile="true" file="ddl/0013_add_correlation_id_index_to_register_check_result_data.xml"/>
 
 </databaseChangeLog>

--- a/src/main/resources/db/changelog/ddl/0013_add_correlation_id_index_to_register_check_result_data.xml
+++ b/src/main/resources/db/changelog/ddl/0013_add_correlation_id_index_to_register_check_result_data.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.1.xsd">
+
+    <changeSet author="kirsty.land@softwire.com" id="0013_add_correlation_id_index_to_register_check_result_data"
+               context="ddl">
+        <createIndex tableName="register_check_result_data"
+                     indexName="register_check_result_data_correlation_id_idx">
+            <column name="correlation_id"/>
+        </createIndex>
+        <rollback>
+            <dropIndex tableName="register_check_result_data"
+                       indexName="register_check_result_data_correlation_id_idx"/>
+        </rollback>
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
The register check removal service uses the findByCorrelationIdIn method in RegisterCheckResultDataRepository, which should be sped up by this index.

The register check service experiences increased latency during the nightly data retention job, and adding this index may improve this.