### PR TITLE
EROPSPT-207: Reset monitoring job on int back to once a day

### DIFF
--- a/src/main/resources/application-int.yml
+++ b/src/main/resources/application-int.yml
@@ -1,3 +1,0 @@
-jobs:
-  register-check-monitoring:
-    cron: "0 */15 * * * *" # Runs every 15 minutes, temporarily, for testing


### PR DESCRIPTION
I temporarily set it to once every 15 minutes while testing, now 

Since it is the only override in the config file, I can delete the file again and let it fall back to application.yml specifying all the properties.