### PR TITLE
EROPSPT-None: Fix register check monitoring tests

### DIFF
--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/job/RegisterCheckMonitoringJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/job/RegisterCheckMonitoringJobIntegrationTest.kt
@@ -78,31 +78,31 @@ internal class RegisterCheckMonitoringJobIntegrationTest : IntegrationTest() {
                 "A total of 3 register checks have been pending for more than PT24H.",
                 Level.INFO
             )
-        )
+        ).isTrue
         assertThat(
             TestLogAppender.hasLog(
                 "The gss code $GSS_CODE_1 has 2 register checks that have been pending for more than PT24H.",
                 Level.INFO
             )
-        )
+        ).isTrue
         assertThat(
             TestLogAppender.hasLog(
                 "The gss code $GSS_CODE_2 has 1 register checks that have been pending for more than PT24H.",
                 Level.INFO
             )
-        )
+        ).isTrue
         assertThat(
             TestLogAppender.hasNoLogMatchingRegex(
                 "The gss code $EXCLUDED_GSS_CODE *",
                 Level.INFO
             )
-        )
+        ).isTrue
         assertThat(
             TestLogAppender.hasNoLogMatchingRegex(
                 "The gss code $GSS_CODE_3 *",
                 Level.INFO
             )
-        )
+        ).isTrue
     }
 
     private fun List<RegisterCheck>.setDateCreatedBeforeOneDayAgo() {

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -11,6 +11,9 @@
     <include resource="org/springframework/boot/logging/logback/base.xml" />
 
     <appender name="testLogAppender" class="uk.gov.dluhc.registercheckerapi.testsupport.TestLogAppender"/>
+    <root level="info">
+        <appender-ref ref="testLogAppender"/>
+    </root>
 
     <logger name="org.testcontainers" level="INFO"/>
     <logger name="com.github.dockerjava" level="WARN"/>


### PR DESCRIPTION
I may have forgotten to assert anything 😢 
Luckily it all appears to work once I actually register the log appender - or at least it did locally. Github / AWS seems upset about an invalid token.