### PR TITLE
EIP1-9811: handle object optimistic locking failure

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/exception/OptimisticLockingFailureException.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/exception/OptimisticLockingFailureException.kt
@@ -1,0 +1,9 @@
+package uk.gov.dluhc.registercheckerapi.exception
+
+import java.util.UUID
+
+/**
+ * Thrown if a Register check has an optimistic locking failure
+ */
+class OptimisticLockingFailureException(correlationId: UUID) :
+    RuntimeException("Register check with requestid:[$correlationId] has an optimistic locking failure")

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/rest/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/rest/GlobalExceptionHandler.kt
@@ -17,6 +17,7 @@ import uk.gov.dluhc.registercheckerapi.client.IerApiException
 import uk.gov.dluhc.registercheckerapi.client.IerEroNotFoundException
 import uk.gov.dluhc.registercheckerapi.config.ApiRequestErrorAttributes
 import uk.gov.dluhc.registercheckerapi.exception.GssCodeMismatchException
+import uk.gov.dluhc.registercheckerapi.exception.OptimisticLockingFailureException
 import uk.gov.dluhc.registercheckerapi.exception.PendingRegisterCheckNotFoundException
 import uk.gov.dluhc.registercheckerapi.exception.Pre1970EarliestSearchException
 import uk.gov.dluhc.registercheckerapi.exception.RegisterCheckMatchCountMismatchException
@@ -75,8 +76,8 @@ class GlobalExceptionHandler(
         return populateErrorResponseAndHandleExceptionInternal(e, HttpStatus.BAD_REQUEST, request)
     }
 
-    @ExceptionHandler(value = [RegisterCheckUnexpectedStatusException::class])
-    fun handleRegisterCheckUnexpectedStatusException(
+    @ExceptionHandler(value = [RegisterCheckUnexpectedStatusException::class, OptimisticLockingFailureException::class])
+    fun handleExceptionReturnConflictResponse(
         e: RuntimeException,
         request: WebRequest
     ): ResponseEntity<Any?>? {


### PR DESCRIPTION
## Description

When two concurrent `updatePendingRegusterCheck` requests are sent at the same time for te same register check result, it can cause an `ObjectOptimisticLockingFailure`. This was being thrown as a 5xx error, but this has now been updated to throw a 409.

## Ticket
https://dluhcdigital.atlassian.net/browse/EIP1-9811