### PR TITLE
EIP1-9811: ensure message is not sent to services when optimistic locking failure happens

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/rest/RegisterCheckerController.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/rest/RegisterCheckerController.kt
@@ -76,7 +76,8 @@ class RegisterCheckerController(
         logger.debug("Post request body validation successful for EMS certificateSerial=[$certificateSerial] with requestId=[$requestId]")
 
         try {
-            registerCheckService.updatePendingRegisterCheck(certificateSerial, registerCheckResultDto)
+            val registerCheck = registerCheckService.updatePendingRegisterCheck(certificateSerial, registerCheckResultDto)
+            registerCheckService.sendConfirmRegisterCheckResultMessage(registerCheck)
         } catch (e: ObjectOptimisticLockingFailureException) {
             throw (OptimisticLockingFailureException(registerCheckResultDto.correlationId)).also {
                 logger.warn { "Register check with correlationId:[${registerCheckResultDto.correlationId}] had an optimistic locking failure" }

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/rest/UpdatePendingRegisterCheckIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/rest/UpdatePendingRegisterCheckIntegrationTest.kt
@@ -503,6 +503,8 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
             .hasStatus(409)
             .hasError("Conflict")
             .hasMessage("Register check with requestid:[14f66386-a86e-4dbc-af52-3327834f33d1] has an optimistic locking failure")
+
+        assertExactlyOneMessageSentToSqs(localStackContainerSettings.mappedQueueUrlConfirmRegisterCheckResult)
     }
 
     @Test
@@ -945,6 +947,13 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
             assertThat(sqsMessages).anyMatch {
                 assertRegisterCheckResultMessage(it, expectedMessageContent)
             }
+        }
+    }
+
+    private fun assertExactlyOneMessageSentToSqs(queueUrl: String) {
+        await.atMost(5, TimeUnit.SECONDS).untilAsserted {
+            val sqsMessages: List<Message> = getLatestSqsMessagesFromQueue(queueUrl)
+            assertThat(sqsMessages.size).isEqualTo(1)
         }
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/RegisterCheckServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/RegisterCheckServiceTest.kt
@@ -23,6 +23,7 @@ import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.registercheckerapi.client.IerEroNotFoundException
 import uk.gov.dluhc.registercheckerapi.client.IerGeneralException
 import uk.gov.dluhc.registercheckerapi.database.entity.CheckStatus
+import uk.gov.dluhc.registercheckerapi.database.entity.CheckStatus.EXACT_MATCH
 import uk.gov.dluhc.registercheckerapi.database.entity.CheckStatus.PENDING
 import uk.gov.dluhc.registercheckerapi.database.entity.RegisterCheckMatch
 import uk.gov.dluhc.registercheckerapi.database.entity.RegisterCheckResultData
@@ -256,32 +257,18 @@ internal class RegisterCheckServiceTest {
 
     @Nested
     inner class SendConfirmRegisterCheckResultMessage {
-        @ParameterizedTest
-        @CsvSource(
-            value = [
-                "0, NO_MATCH, NO_MINUS_MATCH",
-                "1, EXACT_MATCH, EXACT_MINUS_MATCH",
-                "1, PENDING_DETERMINATION, PENDING_MINUS_DETERMINATION",
-                "1, EXPIRED, EXPIRED",
-                "1, NOT_STARTED, NOT_MINUS_STARTED",
-                "10, MULTIPLE_MATCH, MULTIPLE_MINUS_MATCH",
-                "11, TOO_MANY_MATCHES, TOO_MINUS_MANY_MINUS_MATCHES"
-            ]
-        )
-        fun `should submit a ConfirmRegisterCheckResult Message`(
-            matchCount: Int,
-            registerCheckStatus: CheckStatus,
-            registerCheckResult: RegisterCheckResult,
-        ) {
+        @Test
+
+        fun `should submit a ConfirmRegisterCheckResult Message`() {
             // Given
             val requestId = randomUUID()
             val historicalSearchEarliestDate = Instant.now()
-            val registerCheckMatchList = mutableListOf<RegisterCheckMatch>().apply { repeat(matchCount) { add(buildRegisterCheckMatch()) } }
-            val registerCheckMatchListDto = mutableListOf<RegisterCheckMatchDto>().apply { repeat(matchCount) { add(buildRegisterCheckMatchDto()) } }
+            val registerCheckMatchList = mutableListOf<RegisterCheckMatch>().apply { repeat(1) { add(buildRegisterCheckMatch()) } }
+            val registerCheckMatchListDto = mutableListOf<RegisterCheckMatchDto>().apply { repeat(1) { add(buildRegisterCheckMatchDto()) } }
             val savedPendingRegisterCheckEntity = buildRegisterCheck(
                 correlationId = requestId,
-                matchCount = matchCount,
-                status = registerCheckStatus,
+                matchCount = 1,
+                status = EXACT_MATCH,
                 registerCheckMatches = registerCheckMatchList,
                 historicalSearchEarliestDate = historicalSearchEarliestDate,
             )
@@ -289,7 +276,7 @@ internal class RegisterCheckServiceTest {
                 sourceType = SourceType.VOTER_MINUS_CARD,
                 sourceReference = savedPendingRegisterCheckEntity.sourceReference,
                 sourceCorrelationId = savedPendingRegisterCheckEntity.sourceCorrelationId,
-                registerCheckResult = registerCheckResult,
+                registerCheckResult = RegisterCheckResult.EXACT_MINUS_MATCH,
                 matches = registerCheckMatchListDto.map { buildVcaRegisterCheckMatchFromMatchDto(it) },
                 historicalSearchEarliestDate = historicalSearchEarliestDate.atOffset(ZoneOffset.UTC)
             )


### PR DESCRIPTION
## Description

Ensure that when there is an optimistic locking failure, the confirm register check message does not get sent out to the services.

## Ticket
https://dluhcdigital.atlassian.net/browse/EIP1-9811