### PR TITLE
EROSPT-300: Minor email tweaks

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/service/RegisterCheckMonitoringService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/service/RegisterCheckMonitoringService.kt
@@ -37,10 +37,12 @@ class RegisterCheckMonitoringService(
         }
 
         if (sendEmail) {
+            val expectedMaximumPendingHours = expectedMaximumPendingPeriod.toHours().toString()
+
             emailService.sendRegisterCheckMonitoringEmail(
                 stuckRegisterCheckSummaries,
                 totalStuck = totalStuck.toString(),
-                expectedMaximumPendingPeriod = expectedMaximumPendingPeriod.toString(),
+                expectedMaximumPendingPeriod = "$expectedMaximumPendingHours hours",
             )
         }
     }

--- a/src/main/resources/application-dev2.yml
+++ b/src/main/resources/application-dev2.yml
@@ -1,0 +1,3 @@
+jobs:
+  register-check-monitoring:
+    send-email: false

--- a/src/main/resources/application-int.yml
+++ b/src/main/resources/application-int.yml
@@ -1,0 +1,3 @@
+jobs:
+  register-check-monitoring:
+    send-email: false

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -1,0 +1,3 @@
+email:
+  pending-register-checks-content:
+    subject: "[test] Register Check Monitoring"

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/job/RegisterCheckMonitoringJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/job/RegisterCheckMonitoringJobIntegrationTest.kt
@@ -29,6 +29,7 @@ internal class RegisterCheckMonitoringJobIntegrationTest : IntegrationTest() {
         private const val GSS_CODE_3 = "E00000003"
         private const val EXPECTED_TOTAL_STUCK_APPLICATIONS = "3"
         private const val EXPECTED_MAXIMUM_PENDING_PERIOD = "PT24H"
+        private const val EXPECTED_MAXIMUM_PENDING_HOURS = "24"
 
         private const val SENDERS_EMAIL_ADDRESS = "sender@domain.com"
         private const val EMAIL_SUBJECT = "Register Check Monitoring"
@@ -45,7 +46,7 @@ internal class RegisterCheckMonitoringJobIntegrationTest : IntegrationTest() {
     <title>Pending register checks</title>
 </head>
 <body>
-    <p>A total of $EXPECTED_TOTAL_STUCK_APPLICATIONS register checks have been pending for more than $EXPECTED_MAXIMUM_PENDING_PERIOD.</p>
+    <p>A total of $EXPECTED_TOTAL_STUCK_APPLICATIONS register checks have been pending for more than $EXPECTED_MAXIMUM_PENDING_HOURS hours.</p>
     <br>
     <table>
         <thead>

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/EmailServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/EmailServiceTest.kt
@@ -25,7 +25,7 @@ internal class EmailServiceTest {
         private const val GSS_CODE_1 = "E00000001"
         private const val GSS_CODE_2 = "E00000002"
         private const val EXPECTED_TOTAL_STUCK_APPLICATIONS = "3"
-        private const val EXPECTED_MAXIMUM_PENDING_PERIOD = "PT24H"
+        private const val EXPECTED_MAXIMUM_PENDING_PERIOD = "24 hours"
         private val EXPECTED_STUCK_REGISTER_CHECK_SUMMARIES = listOf(
             buildRegisterCheckSummaryByGssCode(gssCode = GSS_CODE_1, registerCheckCount = 2),
             buildRegisterCheckSummaryByGssCode(gssCode = GSS_CODE_2, registerCheckCount = 1),


### PR DESCRIPTION
* Disable email for int and dev2
* Enable email for test env with '[test]' in email subject
* Change email content to say "A total of X register checks have been pending for more than 24 hours." instead of "A total of X register checks have been pending for more than PT24H."