### PR TITLE
EIP1-11144: Update service to support res/req from applications

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,16 @@
+## Describe your changes
+
+## Issue ticket number and link
+
+https://dluhcdigital.atlassian.net/browse/EIP1-
+
+## Checklist before requesting a review
+
+- [ ] I double checked that ACs on the ticket are met by this code update
+- [ ] I have checked any risky steps with my TL ([cheat sheet for safe release here](https://softwiretech.atlassian.net/wiki/spaces/EIP/pages/20960542739/Safe+Release+Cheat+Sheet))
+- [ ] I have added testing steps to the ticket
+- [ ] I have updated the relevant yml versions
+- [ ] I have formatted the code
+- [ ] I have added tests to new code and updated existing tests where needed
+
+## Additional notes

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/config/MessagingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/config/MessagingConfiguration.kt
@@ -26,6 +26,9 @@ class MessagingConfiguration {
     @Value("\${sqs.overseas-vote-confirm-applicant-register-check-result-queue-name}")
     private lateinit var overseasVoteConfirmRegisterCheckResultQueueName: String
 
+    @Value("\${sqs.register-check-result-response-queue-name}")
+    private lateinit var registerCheckResultResponseQueueName: String
+
     @Bean(name = ["confirmRegisterCheckResultQueue"])
     fun confirmRegisterCheckResultQueue(sqsTemplate: SqsTemplate) =
         MessageQueue<RegisterCheckResultMessage>(confirmRegisterCheckResultQueueName, sqsTemplate)
@@ -41,6 +44,10 @@ class MessagingConfiguration {
     @Bean(name = ["overseasVoteConfirmRegisterCheckResultQueue"])
     fun overseasVoteConfirmRegisterCheckResultQueue(sqsTemplate: SqsTemplate) =
         MessageQueue<RegisterCheckResultMessage>(overseasVoteConfirmRegisterCheckResultQueueName, sqsTemplate)
+
+    @Bean(name = ["registerCheckResultResponseQueue"])
+    fun registerCheckResultResponseQueue(sqsTemplate: SqsTemplate) =
+        MessageQueue<RegisterCheckResultMessage>(registerCheckResultResponseQueueName, sqsTemplate)
 
     @Bean
     fun sqsMessagingMessageConverter(

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/entity/RegisterCheck.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/database/entity/RegisterCheck.kt
@@ -161,7 +161,8 @@ enum class SourceType {
     VOTER_CARD,
     POSTAL_VOTE,
     PROXY_VOTE,
-    OVERSEAS_VOTE
+    OVERSEAS_VOTE,
+    APPLICATIONS_API
 }
 
 enum class CheckStatus {

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/dto/PendingRegisterCheckDto.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/dto/PendingRegisterCheckDto.kt
@@ -20,5 +20,6 @@ enum class SourceType {
     VOTER_CARD,
     POSTAL_VOTE,
     PROXY_VOTE,
-    OVERSEAS_VOTE
+    OVERSEAS_VOTE,
+    APPLICATIONS_API
 }

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/mapper/SourceTypeMapper.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/mapper/SourceTypeMapper.kt
@@ -16,12 +16,14 @@ interface SourceTypeMapper {
     @ValueMapping(target = "POSTAL_VOTE", source = "POSTAL_MINUS_VOTE")
     @ValueMapping(target = "PROXY_VOTE", source = "PROXY_MINUS_VOTE")
     @ValueMapping(target = "OVERSEAS_VOTE", source = "OVERSEAS_MINUS_VOTE")
+    @ValueMapping(target = "APPLICATIONS_API", source = "APPLICATIONS_MINUS_API")
     fun fromSqsToDtoEnum(sqsSourceType: SourceTypeSqsEnum): SourceTypeDtoEnum
 
     @ValueMapping(target = "VOTER_MINUS_CARD", source = "VOTER_CARD")
     @ValueMapping(target = "POSTAL_MINUS_VOTE", source = "POSTAL_VOTE")
     @ValueMapping(target = "PROXY_MINUS_VOTE", source = "PROXY_VOTE")
     @ValueMapping(target = "OVERSEAS_MINUS_VOTE", source = "OVERSEAS_VOTE")
+    @ValueMapping(target = "APPLICATIONS_MINUS_API", source = "APPLICATIONS_API")
     fun fromEntityToVcaSqsEnum(entitySourceType: SourceTypeEntityEnum): SourceTypeSqsEnum
 
     fun fromEntityToDtoEnum(entitySourceType: SourceTypeEntityEnum): SourceTypeDtoEnum
@@ -33,5 +35,6 @@ interface SourceTypeMapper {
     @ValueMapping(target = "EROP", source = "POSTAL_VOTE")
     @ValueMapping(target = "EROP", source = "PROXY_VOTE")
     @ValueMapping(target = "EROP", source = "OVERSEAS_VOTE")
+    @ValueMapping(target = "EROP", source = "APPLICATIONS_API")
     fun sourceTypeDtoToSourceSystem(sourceType: SourceType): SourceSystem
 }

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/messaging/MessageQueueResolver.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/messaging/MessageQueueResolver.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Component
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.registercheckerapi.messaging.models.RegisterCheckResultMessage
 import uk.gov.dluhc.registercheckerapi.messaging.models.SourceType
+import uk.gov.dluhc.registercheckerapi.messaging.models.SourceType.APPLICATIONS_MINUS_API
 import uk.gov.dluhc.registercheckerapi.messaging.models.SourceType.OVERSEAS_MINUS_VOTE
 import uk.gov.dluhc.registercheckerapi.messaging.models.SourceType.POSTAL_MINUS_VOTE
 import uk.gov.dluhc.registercheckerapi.messaging.models.SourceType.PROXY_MINUS_VOTE
@@ -16,6 +17,7 @@ class MessageQueueResolver(
     @Qualifier("postalVoteConfirmRegisterCheckResultQueue") private val postalVoteConfirmRegisterCheckResultQueue: MessageQueue<RegisterCheckResultMessage>,
     @Qualifier("proxyVoteConfirmRegisterCheckResultQueue") private val proxyVoteConfirmRegisterCheckResultQueue: MessageQueue<RegisterCheckResultMessage>,
     @Qualifier("overseasVoteConfirmRegisterCheckResultQueue") private val overseasVoteConfirmRegisterCheckResultQueue: MessageQueue<RegisterCheckResultMessage>,
+    @Qualifier("registerCheckResultResponseQueue") private val registerCheckResultResponseQueue: MessageQueue<RegisterCheckResultMessage>,
 ) {
 
     fun getTargetQueueForSourceType(sourceType: SourceType) =
@@ -24,5 +26,6 @@ class MessageQueueResolver(
             POSTAL_MINUS_VOTE -> postalVoteConfirmRegisterCheckResultQueue
             PROXY_MINUS_VOTE -> proxyVoteConfirmRegisterCheckResultQueue
             OVERSEAS_MINUS_VOTE -> overseasVoteConfirmRegisterCheckResultQueue
+            APPLICATIONS_MINUS_API -> registerCheckResultResponseQueue
         }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,6 +35,7 @@ sqs:
   postal-vote-confirm-applicant-register-check-result-queue-name: ${SQS_POSTAL_VOTE_CONFIRM_APPLICANT_REGISTER_CHECK_RESULT_QUEUE_NAME}
   proxy-vote-confirm-applicant-register-check-result-queue-name: ${SQS_PROXY_VOTE_CONFIRM_APPLICANT_REGISTER_CHECK_RESULT_QUEUE_NAME}
   overseas-vote-confirm-applicant-register-check-result-queue-name: ${SQS_OVERSEAS_VOTE_CONFIRM_APPLICANT_REGISTER_CHECK_RESULT_QUEUE_NAME}
+  register-check-result-response-queue-name: ${SQS_REGISTER_CHECK_RESULT_RESPONSE_QUEUE_NAME}
   remove-applicant-register-check-data-queue-name: ${SQS_REMOVE_APPLICANT_REGISTER_CHECK_DATA_QUEUE_NAME}
 
 caching.time-to-live: PT1H

--- a/src/main/resources/openapi/sqs/rca-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/rca-sqs-messaging.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   title: Register Checker SQS Message Types
-  version: '1.2.3'
+  version: '1.3.0'
   description: |-
     Register Checker SQS Message Types
     
@@ -322,6 +322,7 @@ components:
         - postal-vote
         - proxy-vote
         - overseas-vote
+        - applications-api
 
   #
   # Response Body Definitions

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/LocalStackContainerConfiguration.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/LocalStackContainerConfiguration.kt
@@ -94,6 +94,7 @@ class LocalStackContainerConfiguration {
         @Value("\${sqs.postal-vote-confirm-applicant-register-check-result-queue-name}") postalVoteConfirmRegisterCheckResultMessageQueueName: String,
         @Value("\${sqs.proxy-vote-confirm-applicant-register-check-result-queue-name}") proxyVoteConfirmRegisterCheckResultMessageQueueName: String,
         @Value("\${sqs.overseas-vote-confirm-applicant-register-check-result-queue-name}") overseasVoteConfirmRegisterCheckResultMessageQueueName: String,
+        @Value("\${sqs.register-check-result-response-queue-name}") registerCheckResultResponseQueueName: String,
         @Value("\${sqs.remove-applicant-register-check-data-queue-name}") removeRegisterCheckDataMessageQueueName: String,
         objectMapper: ObjectMapper,
     ): LocalStackContainerSettings {
@@ -102,6 +103,7 @@ class LocalStackContainerConfiguration {
         val queueUrlPostalVoteConfirmRegisterCheckResult = localStackContainer.createSqsQueue(postalVoteConfirmRegisterCheckResultMessageQueueName, objectMapper)
         val queueUrlProxyVoteConfirmRegisterCheckResult = localStackContainer.createSqsQueue(proxyVoteConfirmRegisterCheckResultMessageQueueName, objectMapper)
         val queueUrlOverseasVoteConfirmRegisterCheckResult = localStackContainer.createSqsQueue(overseasVoteConfirmRegisterCheckResultMessageQueueName, objectMapper)
+        val queueUrlRegisterCheckResultResponse = localStackContainer.createSqsQueue(registerCheckResultResponseQueueName, objectMapper)
         val queueUrlRemoveRegisterCheckData = localStackContainer.createSqsQueue(removeRegisterCheckDataMessageQueueName, objectMapper)
 
         val apiUrl = "http://${localStackContainer.host}:${localStackContainer.getMappedPort(DEFAULT_PORT)}"
@@ -116,6 +118,7 @@ class LocalStackContainerConfiguration {
             queueUrlProxyVoteConfirmRegisterCheckResult = queueUrlProxyVoteConfirmRegisterCheckResult,
             queueUrlOverseasVoteConfirmRegisterCheckResult = queueUrlOverseasVoteConfirmRegisterCheckResult,
             queueUrlRemoveRegisterCheckData = queueUrlRemoveRegisterCheckData,
+            queueUrlRegisterCheckResultResponse = queueUrlRegisterCheckResultResponse
         )
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/LocalStackContainerSettings.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/LocalStackContainerSettings.kt
@@ -10,12 +10,14 @@ data class LocalStackContainerSettings(
     val queueUrlProxyVoteConfirmRegisterCheckResult: String,
     val queueUrlOverseasVoteConfirmRegisterCheckResult: String,
     val queueUrlRemoveRegisterCheckData: String,
+    val queueUrlRegisterCheckResultResponse: String
 ) {
     val mappedQueueUrlInitiateApplicantRegisterCheck: String = toMappedUrl(queueUrlInitiateApplicantRegisterCheck, apiUrl)
     val mappedQueueUrlConfirmRegisterCheckResult: String = toMappedUrl(queueUrlConfirmRegisterCheckResult, apiUrl)
     val mappedQueueUrlPostalVoteConfirmRegisterCheckResult: String = toMappedUrl(queueUrlPostalVoteConfirmRegisterCheckResult, apiUrl)
     val mappedQueueUrlProxyVoteConfirmRegisterCheckResult: String = toMappedUrl(queueUrlProxyVoteConfirmRegisterCheckResult, apiUrl)
     val mappedQueueUrlOverseasVoteConfirmRegisterCheckResult: String = toMappedUrl(queueUrlOverseasVoteConfirmRegisterCheckResult, apiUrl)
+    val mappedQueueUrlRegisterCheckResultResponse: String = toMappedUrl(queueUrlRegisterCheckResultResponse, apiUrl)
     val mappedQueueUrlRemoveRegisterCheckData: String = toMappedUrl(queueUrlRemoveRegisterCheckData, apiUrl)
     val sesMessagesUrl = "$apiUrl/_aws/ses"
 

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/messaging/MessageQueueResolverTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/messaging/MessageQueueResolverTest.kt
@@ -26,6 +26,9 @@ internal class MessageQueueResolverTest {
     @Mock
     private lateinit var overseasVoteConfirmRegisterCheckResultMockQueue: MessageQueue<RegisterCheckResultMessage>
 
+    @Mock
+    private lateinit var registerCheckResultResponseQueue: MessageQueue<RegisterCheckResultMessage>
+
     private lateinit var messageQueueResolver: MessageQueueResolver
 
     @BeforeEach
@@ -36,6 +39,8 @@ internal class MessageQueueResolverTest {
             proxyVoteConfirmRegisterCheckResultQueue = proxyVoteConfirmRegisterCheckResultMockQueue,
             overseasVoteConfirmRegisterCheckResultQueue = overseasVoteConfirmRegisterCheckResultMockQueue,
             confirmRegisterCheckResultQueue = confirmRegisterCheckResultMockQueue,
+            registerCheckResultResponseQueue = registerCheckResultResponseQueue
+
         )
     }
 
@@ -44,7 +49,8 @@ internal class MessageQueueResolverTest {
         SourceType.VOTER_MINUS_CARD to confirmRegisterCheckResultMockQueue,
         SourceType.POSTAL_MINUS_VOTE to postalVoteConfirmRegisterCheckResultMockQueue,
         SourceType.PROXY_MINUS_VOTE to proxyVoteConfirmRegisterCheckResultMockQueue,
-        SourceType.OVERSEAS_MINUS_VOTE to overseasVoteConfirmRegisterCheckResultMockQueue
+        SourceType.OVERSEAS_MINUS_VOTE to overseasVoteConfirmRegisterCheckResultMockQueue,
+        SourceType.APPLICATIONS_MINUS_API to registerCheckResultResponseQueue
     ).map { (sourceType, expectedTargetQueue) ->
         dynamicTest("for $sourceType return $expectedTargetQueue") {
 

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/messaging/RemoveRegisterCheckDataMessageListenerIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/messaging/RemoveRegisterCheckDataMessageListenerIntegrationTest.kt
@@ -1,11 +1,11 @@
 package uk.gov.dluhc.registercheckerapi.messaging
 
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
 import org.testcontainers.shaded.org.awaitility.Awaitility.await
 import uk.gov.dluhc.registercheckerapi.config.IntegrationTest
-import uk.gov.dluhc.registercheckerapi.database.entity.SourceType.VOTER_CARD
-import uk.gov.dluhc.registercheckerapi.messaging.models.SourceType.VOTER_MINUS_CARD
+import uk.gov.dluhc.registercheckerapi.database.entity.SourceType
 import uk.gov.dluhc.registercheckerapi.testsupport.getRandomGssCode
 import uk.gov.dluhc.registercheckerapi.testsupport.testdata.entity.buildRegisterCheck
 import uk.gov.dluhc.registercheckerapi.testsupport.testdata.entity.buildRegisterCheckResultData
@@ -13,11 +13,24 @@ import uk.gov.dluhc.registercheckerapi.testsupport.testdata.messaging.buildRemov
 import java.util.UUID.fromString
 import java.util.UUID.randomUUID
 import java.util.concurrent.TimeUnit
+import uk.gov.dluhc.registercheckerapi.messaging.models.SourceType as SourceTypeModel
 
 internal class RemoveRegisterCheckDataMessageListenerIntegrationTest : IntegrationTest() {
 
-    @Test
-    fun `should process message received on queue`() {
+    @ParameterizedTest
+    @CsvSource(
+        value = [
+            "VOTER_MINUS_CARD, VOTER_CARD",
+            "POSTAL_MINUS_VOTE, POSTAL_VOTE",
+            "PROXY_MINUS_VOTE, PROXY_VOTE",
+            "OVERSEAS_MINUS_VOTE, OVERSEAS_VOTE",
+            "APPLICATIONS_MINUS_API, APPLICATIONS_API",
+        ]
+    )
+    fun `should process message received on queue for all services`(
+        sourceTypeMessage: SourceTypeModel,
+        expectedSourceType: SourceType
+    ) {
         // Given
         val sourceReference = "93b62b87-0fa4-4d4a-89bf-4486f03f1000"
         val gssCode = "E09000567"
@@ -27,10 +40,10 @@ internal class RemoveRegisterCheckDataMessageListenerIntegrationTest : Integrati
         val correlationIdForOtherSourceRef = fromString("33b62b87-0fa4-4d4a-89bf-4486f03f1333")
         val correlationIdForOtherGssCode = fromString("43b62b87-0fa4-4d4a-89bf-4486f03f1444")
 
-        val registerCheckRecord1 = buildRegisterCheck(sourceReference = sourceReference, gssCode = gssCode, correlationId = correlationIdForCheck1)
-        val registerCheckRecord2 = buildRegisterCheck(sourceReference = sourceReference, gssCode = gssCode, correlationId = correlationIdForCheck2)
-        val registerCheckWithOtherSourceRef = buildRegisterCheck(sourceReference = randomUUID().toString(), gssCode = gssCode, correlationId = correlationIdForOtherSourceRef)
-        val registerCheckWithOtherGssCode = buildRegisterCheck(sourceReference = sourceReference, gssCode = getRandomGssCode(), correlationId = correlationIdForOtherGssCode)
+        val registerCheckRecord1 = buildRegisterCheck(sourceReference = sourceReference, gssCode = gssCode, correlationId = correlationIdForCheck1, sourceType = expectedSourceType)
+        val registerCheckRecord2 = buildRegisterCheck(sourceReference = sourceReference, gssCode = gssCode, correlationId = correlationIdForCheck2, sourceType = expectedSourceType)
+        val registerCheckWithOtherSourceRef = buildRegisterCheck(sourceReference = randomUUID().toString(), gssCode = gssCode, correlationId = correlationIdForOtherSourceRef, sourceType = expectedSourceType)
+        val registerCheckWithOtherGssCode = buildRegisterCheck(sourceReference = sourceReference, gssCode = getRandomGssCode(), correlationId = correlationIdForOtherGssCode, sourceType = expectedSourceType)
         registerCheckRepository.saveAll(listOf(registerCheckRecord1, registerCheckRecord2, registerCheckWithOtherSourceRef, registerCheckWithOtherGssCode))
 
         val registerCheckResultData1a = buildRegisterCheckResultData(correlationId = registerCheckRecord1.correlationId)
@@ -46,7 +59,7 @@ internal class RemoveRegisterCheckDataMessageListenerIntegrationTest : Integrati
         )
 
         val message = buildRemoveRegisterCheckDataMessage(
-            sourceType = VOTER_MINUS_CARD,
+            sourceType = sourceTypeMessage,
             sourceReference = sourceReference,
         )
 
@@ -55,7 +68,7 @@ internal class RemoveRegisterCheckDataMessageListenerIntegrationTest : Integrati
 
         // Then
         await().atMost(5, TimeUnit.SECONDS).untilAsserted {
-            assertThat(registerCheckRepository.findBySourceReferenceAndSourceType(sourceReference, VOTER_CARD)).isEmpty()
+            assertThat(registerCheckRepository.findBySourceReferenceAndSourceType(sourceReference, sourceType = expectedSourceType)).isEmpty()
             assertThat(registerCheckResultDataRepository.findByCorrelationIdIn(setOf(correlationIdForCheck1, correlationIdForCheck2, correlationIdForOtherGssCode))).isEmpty()
 
             assertThat(registerCheckRepository.findByCorrelationId(correlationIdForOtherSourceRef)).isNotNull

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/rest/UpdatePendingRegisterCheckIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/rest/UpdatePendingRegisterCheckIntegrationTest.kt
@@ -880,17 +880,16 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
     @ParameterizedTest
     @CsvSource(
         value = [
-            "VOTER_CARD, VOTER_MINUS_CARD, 000000000000/confirm-applicant-register-check-result",
-            "POSTAL_VOTE, POSTAL_MINUS_VOTE, 000000000000/postal-vote-confirm-applicant-register-check-result",
-            "PROXY_VOTE, PROXY_MINUS_VOTE, 000000000000/proxy-vote-confirm-applicant-register-check-result",
-            "OVERSEAS_VOTE, OVERSEAS_MINUS_VOTE, 000000000000/overseas-vote-confirm-applicant-register-check-result",
-            "APPLICATIONS_API, APPLICATIONS_MINUS_API, 000000000000/register-check-result-response-queue-name",
+            "VOTER_CARD, VOTER_MINUS_CARD,",
+            "POSTAL_VOTE, POSTAL_MINUS_VOTE,",
+            "PROXY_VOTE, PROXY_MINUS_VOTE,",
+            "OVERSEAS_VOTE, OVERSEAS_MINUS_VOTE,",
+            "APPLICATIONS_API, APPLICATIONS_MINUS_API"
         ]
     )
     fun `should submit the different service result messages to the correct queues`(
         sourceTypeEntity: SourceTypeEntity,
-        sourceType: SourceType,
-        rawUrlString: String
+        sourceType: SourceType
     ) {
         // Given
         val requestId = UUID.randomUUID()
@@ -948,10 +947,9 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
             .isCreated
 
         // Then
-        val queueUrl = "${localStackContainerSettings.apiUrl}/$rawUrlString"
-
+        val queueUrlForSourceType = getQueueUrlForSourceType(sourceType)
         assertMessageSubmittedToSqs(
-            queueUrl = queueUrl,
+            queueUrl = queueUrlForSourceType,
             expectedMessageContent = expectedMessageContent
         )
     }
@@ -1067,4 +1065,14 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
 
     private fun buildUri(requestId: UUID = UUID.randomUUID()) =
         "/registerchecks/$requestId"
+
+    private fun getQueueUrlForSourceType(sourceType: SourceType): String {
+        return when (sourceType) {
+            SourceType.APPLICATIONS_MINUS_API -> localStackContainerSettings.mappedQueueUrlRegisterCheckResultResponse
+            SourceType.VOTER_MINUS_CARD -> localStackContainerSettings.mappedQueueUrlConfirmRegisterCheckResult
+            SourceType.PROXY_MINUS_VOTE -> localStackContainerSettings.mappedQueueUrlProxyVoteConfirmRegisterCheckResult
+            SourceType.POSTAL_MINUS_VOTE -> localStackContainerSettings.mappedQueueUrlPostalVoteConfirmRegisterCheckResult
+            SourceType.OVERSEAS_MINUS_VOTE -> localStackContainerSettings.mappedQueueUrlOverseasVoteConfirmRegisterCheckResult
+        }
+    }
 }

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/rest/UpdatePendingRegisterCheckIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/rest/UpdatePendingRegisterCheckIntegrationTest.kt
@@ -880,16 +880,17 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
     @ParameterizedTest
     @CsvSource(
         value = [
-            "VOTER_CARD, VOTER_MINUS_CARD,",
-            "POSTAL_VOTE, POSTAL_MINUS_VOTE,",
-            "PROXY_VOTE, PROXY_MINUS_VOTE,",
-            "OVERSEAS_VOTE, OVERSEAS_MINUS_VOTE,",
-            "APPLICATIONS_API, APPLICATIONS_MINUS_API"
+            "VOTER_CARD, VOTER_MINUS_CARD, 000000000000/confirm-applicant-register-check-result",
+            "POSTAL_VOTE, POSTAL_MINUS_VOTE, 000000000000/postal-vote-confirm-applicant-register-check-result",
+            "PROXY_VOTE, PROXY_MINUS_VOTE, 000000000000/proxy-vote-confirm-applicant-register-check-result",
+            "OVERSEAS_VOTE, OVERSEAS_MINUS_VOTE, 000000000000/overseas-vote-confirm-applicant-register-check-result",
+            "APPLICATIONS_API, APPLICATIONS_MINUS_API, 000000000000/register-check-result-response-queue-name",
         ]
     )
     fun `should submit the different service result messages to the correct queues`(
         sourceTypeEntity: SourceTypeEntity,
-        sourceType: SourceType
+        sourceType: SourceType,
+        rawUrlString: String
     ) {
         // Given
         val requestId = UUID.randomUUID()
@@ -947,28 +948,13 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
             .isCreated
 
         // Then
-        when (sourceType) {
-            SourceType.APPLICATIONS_MINUS_API -> assertMessageSubmittedToSqs(
-                queueUrl = localStackContainerSettings.mappedQueueUrlRegisterCheckResultResponse,
-                expectedMessageContent = expectedMessageContent
-            )
-            SourceType.VOTER_MINUS_CARD -> assertMessageSubmittedToSqs(
-                queueUrl = localStackContainerSettings.mappedQueueUrlConfirmRegisterCheckResult,
-                expectedMessageContent = expectedMessageContent
-            )
-            SourceType.PROXY_MINUS_VOTE -> assertMessageSubmittedToSqs(
-                queueUrl = localStackContainerSettings.mappedQueueUrlProxyVoteConfirmRegisterCheckResult,
-                expectedMessageContent = expectedMessageContent
-            )
-            SourceType.POSTAL_MINUS_VOTE -> assertMessageSubmittedToSqs(
-                queueUrl = localStackContainerSettings.mappedQueueUrlPostalVoteConfirmRegisterCheckResult,
-                expectedMessageContent = expectedMessageContent
-            )
-            SourceType.OVERSEAS_MINUS_VOTE -> assertMessageSubmittedToSqs(
-                queueUrl = localStackContainerSettings.mappedQueueUrlOverseasVoteConfirmRegisterCheckResult,
-                expectedMessageContent = expectedMessageContent
-            )
-        }
+        val queueUrl = "${localStackContainerSettings.apiUrl}/$rawUrlString"
+
+        assertMessageSubmittedToSqs(
+            queueUrl = queueUrl,
+            expectedMessageContent = expectedMessageContent
+        )
+
     }
 
     private fun assertMessageSubmittedToSqs(queueUrl: String, expectedMessageContent: RegisterCheckResultMessage) {

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/rest/UpdatePendingRegisterCheckIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/rest/UpdatePendingRegisterCheckIntegrationTest.kt
@@ -954,7 +954,6 @@ internal class UpdatePendingRegisterCheckIntegrationTest : IntegrationTest() {
             queueUrl = queueUrl,
             expectedMessageContent = expectedMessageContent
         )
-
     }
 
     private fun assertMessageSubmittedToSqs(queueUrl: String, expectedMessageContent: RegisterCheckResultMessage) {

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/RegisterCheckServiceTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/service/RegisterCheckServiceTest.kt
@@ -53,6 +53,7 @@ import java.time.Instant
 import java.time.ZoneOffset
 import java.util.UUID
 import java.util.UUID.randomUUID
+import uk.gov.dluhc.registercheckerapi.database.entity.SourceType as SourceTypeEntity
 
 @ExtendWith(MockitoExtension::class)
 internal class RegisterCheckServiceTest {
@@ -257,9 +258,21 @@ internal class RegisterCheckServiceTest {
 
     @Nested
     inner class SendConfirmRegisterCheckResultMessage {
-        @Test
 
-        fun `should submit a ConfirmRegisterCheckResult Message`() {
+        @ParameterizedTest
+        @CsvSource(
+            value = [
+                "VOTER_CARD, VOTER_MINUS_CARD",
+                "POSTAL_VOTE, POSTAL_MINUS_VOTE",
+                "PROXY_VOTE, PROXY_MINUS_VOTE",
+                "OVERSEAS_VOTE, OVERSEAS_MINUS_VOTE",
+                "APPLICATIONS_API, APPLICATIONS_MINUS_API"
+            ]
+        )
+        fun `should submit a ConfirmRegisterCheckResult Message for all services`(
+            sourceTypeDto: SourceTypeEntity,
+            sourceType: SourceType
+        ) {
             // Given
             val requestId = randomUUID()
             val historicalSearchEarliestDate = Instant.now()
@@ -271,6 +284,7 @@ internal class RegisterCheckServiceTest {
                 status = EXACT_MATCH,
                 registerCheckMatches = registerCheckMatchList,
                 historicalSearchEarliestDate = historicalSearchEarliestDate,
+                sourceType = sourceTypeDto
             )
             val expectedMessage = buildRegisterCheckResultMessage(
                 sourceType = SourceType.VOTER_MINUS_CARD,

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -49,6 +49,7 @@ sqs:
   postal-vote-confirm-applicant-register-check-result-queue-name: postal-vote-confirm-applicant-register-check-result
   proxy-vote-confirm-applicant-register-check-result-queue-name: proxy-vote-confirm-applicant-register-check-result
   overseas-vote-confirm-applicant-register-check-result-queue-name: overseas-vote-confirm-applicant-register-check-result
+  register-check-result-response-queue-name: register-check-result-response-queue-name
 
 caching.time-to-live: PT2S
 


### PR DESCRIPTION
## Describe your changes

Add functionality to put messages on a new queue that will send messages to the applications API. This queue will send messages when register checks are updated. I have named this queue `register-check-result-response-queue` in accordance with whats been done in Infra and to keep the name generic (as it will only be used in the applications API after decommissioning)

Add tests to check that messages will go on this queue when the `sourceType = applications-api` 

Add the PR template 

## Issue ticket number and link

https://dluhcdigital.atlassian.net/browse/EIP1-11144

## Checklist before requesting a review

- [x] I double checked that ACs on the ticket are met by this code update
- [ ] I have checked any risky steps with my TL ([cheat sheet for safe release here](https://softwiretech.atlassian.net/wiki/spaces/EIP/pages/20960542739/Safe+Release+Cheat+Sheet))
- [ ] I have added testing steps to the ticket
- [x] I have updated the relevant yml versions
- [x] I have formatted the code
- [x] I have added tests to new code and updated existing tests where needed

## Additional notes