### PR TITLE
EIP1-11115: add message forwarding for migration of register checker to ems integration api

### DIFF
--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/config/MessagingConfiguration.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/config/MessagingConfiguration.kt
@@ -9,7 +9,10 @@ import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.services.sqs.SqsAsyncClient
 import uk.gov.dluhc.messagingsupport.MessageQueue
 import uk.gov.dluhc.messagingsupport.MessagingConfigurationHelper
+import uk.gov.dluhc.registercheckerapi.messaging.models.InitiateRegisterCheckMessage
+import uk.gov.dluhc.registercheckerapi.messaging.models.PendingRegisterCheckArchiveMessage
 import uk.gov.dluhc.registercheckerapi.messaging.models.RegisterCheckResultMessage
+import uk.gov.dluhc.registercheckerapi.messaging.models.RemoveRegisterCheckDataMessage
 
 @Configuration
 class MessagingConfiguration {
@@ -28,6 +31,15 @@ class MessagingConfiguration {
 
     @Value("\${sqs.register-check-result-response-queue-name}")
     private lateinit var registerCheckResultResponseQueueName: String
+
+    @Value("\${sqs.forward-initiate-register-check-queue-name}")
+    private lateinit var forwardInitiateRegisterCheckQueueName: String
+
+    @Value("\${sqs.send-register-check-archive-message-queue-name}")
+    private lateinit var sendRegisterCheckArchiveMessageQueueName: String
+
+    @Value("\${sqs.forward-remove-register-check-data-message-queue-name}")
+    private lateinit var forwardRemoveRegisterCheckDataMessageQueueName: String
 
     @Bean(name = ["confirmRegisterCheckResultQueue"])
     fun confirmRegisterCheckResultQueue(sqsTemplate: SqsTemplate) =
@@ -48,6 +60,18 @@ class MessagingConfiguration {
     @Bean(name = ["registerCheckResultResponseQueue"])
     fun registerCheckResultResponseQueue(sqsTemplate: SqsTemplate) =
         MessageQueue<RegisterCheckResultMessage>(registerCheckResultResponseQueueName, sqsTemplate)
+
+    @Bean(name = ["forwardInitiateRegisterCheckQueue"])
+    fun forwardInitiateRegisterCheckQueue(sqsTemplate: SqsTemplate) =
+        MessageQueue<InitiateRegisterCheckMessage>(forwardInitiateRegisterCheckQueueName, sqsTemplate)
+
+    @Bean(name = ["sendRegisterCheckArchiveMessageQueue"])
+    fun sendRegisterCheckArchiveMessageQueue(sqsTemplate: SqsTemplate) =
+        MessageQueue<PendingRegisterCheckArchiveMessage>(sendRegisterCheckArchiveMessageQueueName, sqsTemplate)
+
+    @Bean(name = ["forwardRemoveRegisterCheckDataMessageQueue"])
+    fun forwardRemoveRegisterCheckDataMessageQueue(sqsTemplate: SqsTemplate) =
+        MessageQueue<RemoveRegisterCheckDataMessage>(forwardRemoveRegisterCheckDataMessageQueueName, sqsTemplate)
 
     @Bean
     fun sqsMessagingMessageConverter(

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/messaging/InitiateRegisterCheckMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/messaging/InitiateRegisterCheckMessageListener.kt
@@ -9,6 +9,7 @@ import uk.gov.dluhc.messagingsupport.MessageListener
 import uk.gov.dluhc.registercheckerapi.messaging.mapper.InitiateRegisterCheckMapper
 import uk.gov.dluhc.registercheckerapi.messaging.models.InitiateRegisterCheckMessage
 import uk.gov.dluhc.registercheckerapi.service.RegisterCheckService
+import uk.gov.dluhc.registercheckerapi.service.ReplicationMessagingService
 
 private val logger = KotlinLogging.logger { }
 
@@ -18,7 +19,8 @@ private val logger = KotlinLogging.logger { }
 @Component
 class InitiateRegisterCheckMessageListener(
     private val registerCheckService: RegisterCheckService,
-    private val mapper: InitiateRegisterCheckMapper
+    private val mapper: InitiateRegisterCheckMapper,
+    private val replicationMessagingService: ReplicationMessagingService,
 ) :
     MessageListener<InitiateRegisterCheckMessage> {
 
@@ -32,6 +34,7 @@ class InitiateRegisterCheckMessageListener(
             }
             val pendingRegisterCheckDto = mapper.initiateCheckMessageToPendingRegisterCheckDto(this)
             registerCheckService.save(pendingRegisterCheckDto)
+            replicationMessagingService.forwardInitiateRegisterCheckMessage(request = payload)
         }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/messaging/RemoveRegisterCheckDataMessageListener.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/messaging/RemoveRegisterCheckDataMessageListener.kt
@@ -9,6 +9,7 @@ import uk.gov.dluhc.messagingsupport.MessageListener
 import uk.gov.dluhc.registercheckerapi.messaging.mapper.RegisterCheckRemovalMapper
 import uk.gov.dluhc.registercheckerapi.messaging.models.RemoveRegisterCheckDataMessage
 import uk.gov.dluhc.registercheckerapi.service.RegisterCheckRemovalService
+import uk.gov.dluhc.registercheckerapi.service.ReplicationMessagingService
 
 private val logger = KotlinLogging.logger { }
 
@@ -18,6 +19,7 @@ private val logger = KotlinLogging.logger { }
 @Component
 class RemoveRegisterCheckDataMessageListener(
     private val registerCheckRemovalService: RegisterCheckRemovalService,
+    private val replicationMessagingService: ReplicationMessagingService,
     private val mapper: RegisterCheckRemovalMapper
 ) : MessageListener<RemoveRegisterCheckDataMessage> {
 
@@ -30,6 +32,11 @@ class RemoveRegisterCheckDataMessageListener(
                     "sourceReference: [$sourceReference]"
             }
             registerCheckRemovalService.removeRegisterCheckData(mapper.toRemovalDto(this))
+            val removeDataMessage = RemoveRegisterCheckDataMessage(
+                sourceType,
+                sourceReference,
+            )
+            replicationMessagingService.forwardRemoveRegisterCheckDataMessage(removeDataMessage)
         }
     }
 }

--- a/src/main/kotlin/uk/gov/dluhc/registercheckerapi/service/ReplicationMessagingService.kt
+++ b/src/main/kotlin/uk/gov/dluhc/registercheckerapi/service/ReplicationMessagingService.kt
@@ -1,0 +1,28 @@
+package uk.gov.dluhc.registercheckerapi.service
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.stereotype.Service
+import uk.gov.dluhc.messagingsupport.MessageQueue
+import uk.gov.dluhc.registercheckerapi.messaging.models.InitiateRegisterCheckMessage
+import uk.gov.dluhc.registercheckerapi.messaging.models.PendingRegisterCheckArchiveMessage
+import uk.gov.dluhc.registercheckerapi.messaging.models.RemoveRegisterCheckDataMessage
+
+@Service
+class ReplicationMessagingService(
+    @Qualifier("forwardInitiateRegisterCheckQueue") private val initiateCheckMessageQueue: MessageQueue<InitiateRegisterCheckMessage>,
+    @Qualifier("sendRegisterCheckArchiveMessageQueue") private val archiveRegisterCheckMessageQueue: MessageQueue<PendingRegisterCheckArchiveMessage>,
+    @Qualifier("forwardRemoveRegisterCheckDataMessageQueue") private val removeRegisterCheckDataMessageQueue: MessageQueue<RemoveRegisterCheckDataMessage>,
+) {
+
+    fun forwardInitiateRegisterCheckMessage(request: InitiateRegisterCheckMessage) {
+        initiateCheckMessageQueue.submit(request)
+    }
+
+    fun sendArchiveRegisterCheckMessage(request: PendingRegisterCheckArchiveMessage) {
+        archiveRegisterCheckMessageQueue.submit(request)
+    }
+
+    fun forwardRemoveRegisterCheckDataMessage(request: RemoveRegisterCheckDataMessage) {
+        removeRegisterCheckDataMessageQueue.submit(request)
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -37,6 +37,9 @@ sqs:
   overseas-vote-confirm-applicant-register-check-result-queue-name: ${SQS_OVERSEAS_VOTE_CONFIRM_APPLICANT_REGISTER_CHECK_RESULT_QUEUE_NAME}
   register-check-result-response-queue-name: ${SQS_REGISTER_CHECK_RESULT_RESPONSE_QUEUE_NAME}
   remove-applicant-register-check-data-queue-name: ${SQS_REMOVE_APPLICANT_REGISTER_CHECK_DATA_QUEUE_NAME}
+  forward-initiate-register-check-queue-name: ${SQS_INITIATE_REGISTER_CHECK_QUEUE_NAME}
+  send-register-check-archive-message-queue-name: ${SQS_ARCHIVE_REGISTER_CHECK_QUEUE_NAME}
+  forward-remove-register-check-data-message-queue-name: ${SQS_REMOVE_APPLICATION_REGISTER_CHECK_DATA_QUEUE_NAME}
 
 caching.time-to-live: PT1H
 

--- a/src/main/resources/openapi/sqs/rca-sqs-messaging.yaml
+++ b/src/main/resources/openapi/sqs/rca-sqs-messaging.yaml
@@ -161,6 +161,20 @@ components:
         - registerCheckResult
         - matches
 
+    PendingRegisterCheckArchiveMessage:
+      title: PendingRegisterCheckArchiveMessage
+      type: object
+      description: SQS message containing a request to archive all data related to a register check
+      properties:
+        correlationId:
+          type: string
+          format: uuid
+          description: The id to allow the response from rca to be associated with the correct register status e.g. `VoterCardApplicationRegisterStatus.id`
+          example: c73bcdcc-2669-4bf6-81d3-e4ae73fb11fd
+
+      required:
+        - correlationId
+
     RegisterCheckResult:
       title: RegisterCheckResult
       description: Enum containing the possible values for a register check match outcome.

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/IntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.dluhc.registercheckerapi.database.repository.RegisterCheckReposito
 import uk.gov.dluhc.registercheckerapi.database.repository.RegisterCheckResultDataRepository
 import uk.gov.dluhc.registercheckerapi.database.repository.VotingArrangementRepository
 import uk.gov.dluhc.registercheckerapi.mapper.SourceTypeMapper
+import uk.gov.dluhc.registercheckerapi.service.ReplicationMessagingService
 import uk.gov.dluhc.registercheckerapi.testsupport.TestLogAppender
 import uk.gov.dluhc.registercheckerapi.testsupport.WiremockService
 import uk.gov.dluhc.registercheckerapi.testsupport.emails.EmailMessagesSentClient
@@ -85,6 +86,9 @@ internal abstract class IntegrationTest {
 
     @Value("\${caching.time-to-live}")
     protected lateinit var timeToLive: Duration
+
+    @Autowired
+    protected lateinit var replicationMessagingService: ReplicationMessagingService
 
     companion object {
         @JvmStatic

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/LocalStackContainerConfiguration.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/LocalStackContainerConfiguration.kt
@@ -96,6 +96,9 @@ class LocalStackContainerConfiguration {
         @Value("\${sqs.overseas-vote-confirm-applicant-register-check-result-queue-name}") overseasVoteConfirmRegisterCheckResultMessageQueueName: String,
         @Value("\${sqs.register-check-result-response-queue-name}") registerCheckResultResponseQueueName: String,
         @Value("\${sqs.remove-applicant-register-check-data-queue-name}") removeRegisterCheckDataMessageQueueName: String,
+        @Value("\${sqs.forward-initiate-register-check-queue-name}") forwardInitiateRegisterCheckQueueName: String,
+        @Value("\${sqs.send-register-check-archive-message-queue-name}") sendRegisterCheckArchiveMessageQueueName: String,
+        @Value("\${sqs.forward-remove-register-check-data-message-queue-name}") forwardRemoveRegisterCheckDataQueueName: String,
         objectMapper: ObjectMapper,
     ): LocalStackContainerSettings {
         val queueUrlInitiateApplicantRegisterCheck = localStackContainer.createSqsQueue(initiateApplicantRegisterCheckQueueName, objectMapper)
@@ -105,6 +108,9 @@ class LocalStackContainerConfiguration {
         val queueUrlOverseasVoteConfirmRegisterCheckResult = localStackContainer.createSqsQueue(overseasVoteConfirmRegisterCheckResultMessageQueueName, objectMapper)
         val queueUrlRegisterCheckResultResponse = localStackContainer.createSqsQueue(registerCheckResultResponseQueueName, objectMapper)
         val queueUrlRemoveRegisterCheckData = localStackContainer.createSqsQueue(removeRegisterCheckDataMessageQueueName, objectMapper)
+        val queueUrlForwardInitiateRegisterCheckData = localStackContainer.createSqsQueue(forwardInitiateRegisterCheckQueueName, objectMapper)
+        val queueUrlSendRegisterCheckArchiveMessageData = localStackContainer.createSqsQueue(sendRegisterCheckArchiveMessageQueueName, objectMapper)
+        val queueUrlForwardRemoveRegisterCheckData = localStackContainer.createSqsQueue(forwardRemoveRegisterCheckDataQueueName, objectMapper)
 
         val apiUrl = "http://${localStackContainer.host}:${localStackContainer.getMappedPort(DEFAULT_PORT)}"
 
@@ -118,7 +124,10 @@ class LocalStackContainerConfiguration {
             queueUrlProxyVoteConfirmRegisterCheckResult = queueUrlProxyVoteConfirmRegisterCheckResult,
             queueUrlOverseasVoteConfirmRegisterCheckResult = queueUrlOverseasVoteConfirmRegisterCheckResult,
             queueUrlRemoveRegisterCheckData = queueUrlRemoveRegisterCheckData,
-            queueUrlRegisterCheckResultResponse = queueUrlRegisterCheckResultResponse
+            queueUrlRegisterCheckResultResponse = queueUrlRegisterCheckResultResponse,
+            queueUrlForwardInitiateRegisterCheckData = queueUrlForwardInitiateRegisterCheckData,
+            queueUrlSendRegisterCheckArchiveMessageData = queueUrlSendRegisterCheckArchiveMessageData,
+            queueUrlForwardRemoveRegisterCheckData = queueUrlForwardRemoveRegisterCheckData,
         )
     }
 

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/LocalStackContainerSettings.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/config/LocalStackContainerSettings.kt
@@ -10,7 +10,10 @@ data class LocalStackContainerSettings(
     val queueUrlProxyVoteConfirmRegisterCheckResult: String,
     val queueUrlOverseasVoteConfirmRegisterCheckResult: String,
     val queueUrlRemoveRegisterCheckData: String,
-    val queueUrlRegisterCheckResultResponse: String
+    val queueUrlRegisterCheckResultResponse: String,
+    val queueUrlForwardInitiateRegisterCheckData: String,
+    val queueUrlSendRegisterCheckArchiveMessageData: String,
+    val queueUrlForwardRemoveRegisterCheckData: String
 ) {
     val mappedQueueUrlInitiateApplicantRegisterCheck: String = toMappedUrl(queueUrlInitiateApplicantRegisterCheck, apiUrl)
     val mappedQueueUrlConfirmRegisterCheckResult: String = toMappedUrl(queueUrlConfirmRegisterCheckResult, apiUrl)
@@ -19,6 +22,9 @@ data class LocalStackContainerSettings(
     val mappedQueueUrlOverseasVoteConfirmRegisterCheckResult: String = toMappedUrl(queueUrlOverseasVoteConfirmRegisterCheckResult, apiUrl)
     val mappedQueueUrlRegisterCheckResultResponse: String = toMappedUrl(queueUrlRegisterCheckResultResponse, apiUrl)
     val mappedQueueUrlRemoveRegisterCheckData: String = toMappedUrl(queueUrlRemoveRegisterCheckData, apiUrl)
+    val mappedQueueUrlForwardInitiateRegisterCheckData: String = toMappedUrl(queueUrlForwardInitiateRegisterCheckData, apiUrl)
+    val mappedQueueUrlSendRegisterCheckArchiveMessageData: String = toMappedUrl(queueUrlSendRegisterCheckArchiveMessageData, apiUrl)
+    val mappedQueueUrlForwardRemoveRegisterCheckData: String = toMappedUrl(queueUrlForwardRemoveRegisterCheckData, apiUrl)
     val sesMessagesUrl = "$apiUrl/_aws/ses"
 
     private fun toMappedUrl(rawUrlString: String, apiUrlString: String): String {

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/messaging/InitiateRegisterCheckMessageListenerTest.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/messaging/InitiateRegisterCheckMessageListenerTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.dluhc.registercheckerapi.messaging
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.given
+import uk.gov.dluhc.registercheckerapi.messaging.mapper.InitiateRegisterCheckMapper
+import uk.gov.dluhc.registercheckerapi.service.RegisterCheckService
+import uk.gov.dluhc.registercheckerapi.service.ReplicationMessagingService
+import uk.gov.dluhc.registercheckerapi.testsupport.testdata.dto.buildPendingRegisterCheckDto
+import uk.gov.dluhc.registercheckerapi.testsupport.testdata.messaging.buildInitiateRegisterCheckMessage
+
+@ExtendWith(MockitoExtension::class)
+class InitiateRegisterCheckMessageListenerTest {
+
+    @Mock
+    private lateinit var registerCheckService: RegisterCheckService
+
+    @Mock
+    private lateinit var mapper: InitiateRegisterCheckMapper
+
+    @Mock
+    private lateinit var replicationMessagingService: ReplicationMessagingService
+
+    @InjectMocks
+    private lateinit var objectUnderTest: InitiateRegisterCheckMessageListener
+
+    @Test
+    fun `should save and forward initiate register check message`() {
+        // Given
+        val payload = buildInitiateRegisterCheckMessage()
+        val buildPendingRegisterCheckDto = buildPendingRegisterCheckDto()
+
+        given(mapper.initiateCheckMessageToPendingRegisterCheckDto(any())).willReturn(buildPendingRegisterCheckDto)
+
+        // When
+        objectUnderTest.handleMessage(payload)
+
+        // Then
+        verify(mapper).initiateCheckMessageToPendingRegisterCheckDto(payload)
+        verify(registerCheckService).save(any())
+        verify(replicationMessagingService).forwardInitiateRegisterCheckMessage(payload)
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/testsupport/ClearDownUtils.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/testsupport/ClearDownUtils.kt
@@ -1,0 +1,17 @@
+package uk.gov.dluhc.registercheckerapi.testsupport
+
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.PurgeQueueRequest
+
+object ClearDownUtils {
+
+    fun clearDownRecords(
+        sqsAsyncClient: SqsAsyncClient? = null,
+        queueName: String? = null
+    ) {
+        queueName?.let {
+            val request = PurgeQueueRequest.builder().queueUrl(queueName).build()
+            sqsAsyncClient?.purgeQueue(request)
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/dluhc/registercheckerapi/testsupport/MessagingTestHelper.kt
+++ b/src/test/kotlin/uk/gov/dluhc/registercheckerapi/testsupport/MessagingTestHelper.kt
@@ -1,0 +1,21 @@
+package uk.gov.dluhc.registercheckerapi.testsupport
+
+import org.assertj.core.api.Assertions.assertThat
+import software.amazon.awssdk.services.sqs.SqsAsyncClient
+import software.amazon.awssdk.services.sqs.model.ReceiveMessageRequest
+
+class MessagingTestHelper(
+    private val sqsAsyncClient: SqsAsyncClient
+) {
+
+    fun assertMessagesEnqueued(queueUrl: String, expectedNumMessages: Int) {
+        val receiveMessageRequest = ReceiveMessageRequest.builder()
+            .queueUrl(queueUrl)
+            .maxNumberOfMessages(10)
+            .build()
+        val sqsMessages = sqsAsyncClient.receiveMessage(receiveMessageRequest)
+            .get()
+            .messages()
+        assertThat(sqsMessages.size).isEqualTo(expectedNumMessages)
+    }
+}

--- a/src/test/resources/application-integration-test.yml
+++ b/src/test/resources/application-integration-test.yml
@@ -49,7 +49,10 @@ sqs:
   postal-vote-confirm-applicant-register-check-result-queue-name: postal-vote-confirm-applicant-register-check-result
   proxy-vote-confirm-applicant-register-check-result-queue-name: proxy-vote-confirm-applicant-register-check-result
   overseas-vote-confirm-applicant-register-check-result-queue-name: overseas-vote-confirm-applicant-register-check-result
-  register-check-result-response-queue-name: register-check-result-response-queue-name
+  register-check-result-response-queue-name: register-check-result-response
+  forward-initiate-register-check-queue-name: forward-initiate-register-check
+  send-register-check-archive-message-queue-name: send-register-check-archive-message
+  forward-remove-register-check-data-message-queue-name: forward-remove-register-check-data-message
 
 caching.time-to-live: PT2S
 


### PR DESCRIPTION
## Describe your changes
Three new message types are enqueued downstream from the register checker processing: -
 - forwarding the initiate register checks message to the ems when consuming same message from initiate applicant register check queue
 - sending a new archive register check message to the ems when handling POST to register checks endpoint
 - forwarding the remove register check data message to the ems when consuming from remove applicant register check data queue
 
Corresponding changes are being made under branch [`EIP1-11115-support-register-check-replication`](https://github.com/communitiesuk/eip-ero-ems-integration-api/tree/EIP1-11115-support-register-check-replication) to the ems integration api to consume the new messages and complete the acceptance criteria for this ticket.

## Issue ticket number and link
https://dluhcdigital.atlassian.net/browse/EIP1-11115

## Checklist before requesting a review

- [X] I double checked that ACs on the ticket are met by this code update
- [ ] I have checked any risky steps with my TL ([cheat sheet for safe release here](https://softwiretech.atlassian.net/wiki/spaces/EIP/pages/20960542739/Safe+Release+Cheat+Sheet))
- [ ] I have added testing steps to the ticket
- [ ] I have updated the relevant yml versions
- [ ] I have formatted the code
- [ ] I have added tests to new code and updated existing tests where needed

## Additional notes
