### PR TITLE
 EROPSPT-443: Upgrade SB to 3.4.5 and dependency checker to 12.1.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 import java.lang.ProcessBuilder.Redirect
 
 plugins {
-    id("org.springframework.boot") version "3.4.4"
+    id("org.springframework.boot") version "3.4.5"
     id("io.spring.dependency-management") version "1.1.3"
     kotlin("jvm") version "1.9.24"
     kotlin("kapt") version "1.9.24"
@@ -16,7 +16,7 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint") version "11.0.0"
     id("org.jlleitschuh.gradle.ktlint-idea") version "11.0.0"
     id("org.openapi.generator") version "7.0.1"
-    id("org.owasp.dependencycheck") version "12.1.0"
+    id("org.owasp.dependencycheck") version "12.1.1"
 }
 
 group = "uk.gov.dluhc"


### PR DESCRIPTION
Upgrading to SB 3.4.5 resolves CVE-2025-22234, CVE-2025-22235, and CVE-2025-27820. It also resolve the dependency clash with dependency-checker 12.1.1, which fixes bugs present in older versions of the dependency checker.